### PR TITLE
[fix] Missing i386 arch

### DIFF
--- a/conf/i386.src
+++ b/conf/i386.src
@@ -1,0 +1,7 @@
+SOURCE_URL=https://dl.vikunja.io/api/0.18.1/vikunja-v0.18.1-linux-386-full
+SOURCE_SUM=c6f3df58094e934e4e59d1afece8cfa5ea9696983be1a6225b4e4e8f57b0afd1
+SOURCE_SUM_PRG=sha256sum
+SOURCE_IN_SUBDIR=false
+SOURCE_FORMAT=zip
+SOURCE_FILENAME=vikunja
+SOURCE_EXTRACT=true


### PR DESCRIPTION
## Problem

Upstream support i386 but the package doesn't
https://paste.yunohost.org/raw/fedemidize

## Solution

Add src for i386

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
