### PR TITLE
Add autoupdate strategy

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -59,11 +59,17 @@ ram.runtime = "50M"
         i386.url = "https://dl.vikunja.io/api/0.22.0/vikunja-v0.22.0-linux-386-full.zip"
         i386.sha256 = "29b5cbbd3ad2f2c9c9b2a63a4ae0f60a20baf4b30519aafbc02e88fb1d177c88"
         in_subdir = false
+        format = "zip"
+        autoupdate.upstream = "https://github.com/go-vikunja/api"
+        autoupdate.strategy = "latest_github_tag"
         
         [resources.sources.front]
         url = "https://dl.vikunja.io/frontend/vikunja-frontend-0.22.0.zip"
         sha256 = "2d85352060214993b0308e381d6e487dc04ab3d46453f21719580f1832a7280b"
         in_subdir = false
+        format = "zip"
+        autoupdate.upstream = "https://github.com/go-vikunja/frontend"
+        autoupdate.strategy = "latest_github_tag"
 
     [resources.ports]
 


### PR DESCRIPTION
## Problem

Currently app needs to be updated manually.

## Solution

Add basic autoupdate strategy (serving as reminder for new version release, not fully working yet). The issue here is that the sources are not downloaded from [Gitea](https://kolaente.dev/vikunja) or the [mirrored GitHub repositories](https://github.com/go-vikunja) but from the [official download server](https://dl.vikunja.io/).

As far as I know there is no autoupdate strategy to check a custom download server. So, as a workaround I defined GitHub as custom autoupdate upstream to have at least a reminder when a new version has been released. Note, that this is not fully functioning automatically as it just pulls general zip files for frontend and api which might not be suitable for the different architectures (e.g. arm64, amd64, armhf, i386). So, for now the PRs would need to be adjusted manually.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
