### PR TITLE
Update to 0.22.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Vikunja is a self-hosted open-source to-do list application for all platforms.
 - CalDAV
 - Links  
 
-**Shipped version:** 0.22.0~ynh1
+**Shipped version:** 0.22.1~ynh1
 
 **Demo:** https://try.vikunja.io/login
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -27,7 +27,7 @@ Vikunja est une application de liste de tâches Open Source auto-hébergée pour
 - CalDAV
 - Links  
 
-**Version incluse :** 0.22.0~ynh1
+**Version incluse :** 0.22.1~ynh1
 
 **Démo :** https://try.vikunja.io/login
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Vikunja"
 description.en = "Self-hosted To-Do list application"
 description.fr = "Application de liste de tâches auto-hébergée"
 
-version = "0.22.0~ynh1"
+version = "0.22.1~ynh1"
 
 maintainers = ["eric_G"]
 
@@ -50,19 +50,19 @@ ram.runtime = "50M"
 
     [resources.sources]
         [resources.sources.back]
-        arm64.url = "https://dl.vikunja.io/api/0.22.0/vikunja-v0.22.0-linux-arm64-full.zip"
-        arm64.sha256 = "946d172c9bc4a42d51db5d6d2fac9ca22b00faaf2a961c8f3bd5831770ebbfd1"
-        amd64.url = "https://dl.vikunja.io/api/0.22.0/vikunja-v0.22.0-linux-amd64-full.zip"
-        amd64.sha256 = "754a819377f0753c2ecc323c876b3681b6cd5afebd408a370b45801e93a15d92"
-        armhf.url = "https://dl.vikunja.io/api/0.22.0/vikunja-v0.22.0-linux-arm-7-full.zip"
-        armhf.sha256 = "e2169d9ee9fed32618f87dd3548ce8cd6ad2ee722601f9eb0e26c998dae7784c"
-        i386.url = "https://dl.vikunja.io/api/0.22.0/vikunja-v0.22.0-linux-386-full.zip"
-        i386.sha256 = "29b5cbbd3ad2f2c9c9b2a63a4ae0f60a20baf4b30519aafbc02e88fb1d177c88"
+        arm64.url = "https://dl.vikunja.io/api/0.22.1/vikunja-v0.22.1-linux-arm64-full.zip"
+        arm64.sha256 = "50a1670c0fde858c1cd7bc72cc670c4011a688a20b07ee62fab11bcca3eab01e"
+        amd64.url = "https://dl.vikunja.io/api/0.22.1/vikunja-v0.22.1-linux-amd64-full.zip"
+        amd64.sha256 = "c3e21ca5ccace3f9eaa423bab8c1cfc3e7de15d5c593db0aa6e4dbd9883469e6"
+        armhf.url = "https://dl.vikunja.io/api/0.22.1/vikunja-v0.22.1-linux-arm-7-full.zip"
+        armhf.sha256 = "72f50404df57d75060bdd0d162e12cba20269a0def7b38993e1b61c4cf3d69d2"
+        i386.url = "https://dl.vikunja.io/api/0.22.1/vikunja-v0.22.1-linux-386-full.zip"
+        i386.sha256 = "de1e271b6d3fe6024b790b95c1bf946a415598b31192638ef85589cd2c35f996"
         in_subdir = false
         
         [resources.sources.front]
-        url = "https://dl.vikunja.io/frontend/vikunja-frontend-0.22.0.zip"
-        sha256 = "2d85352060214993b0308e381d6e487dc04ab3d46453f21719580f1832a7280b"
+        url = "https://dl.vikunja.io/frontend/vikunja-frontend-0.22.1.zip"
+        sha256 = "8e4145eacb9c2d95a95a43dca2f4dd0fd30ec8934f4562017caf77f3c5f9a277"
         in_subdir = false
 
     [resources.ports]


### PR DESCRIPTION
## Problem

Version 0.22.1 was released: https://vikunja.io/blog/2024/01/vikunja-frontend-and-api-v0.22.1-was-released/ 

## Solution

Updated zips urls and hash sums.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
