### PR TITLE
Update to 0.24.2

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Vikunja"
 description.en = "Self-hosted To-Do list application"
 description.fr = "Application de liste de tâches auto-hébergée"
 
-version = "0.24.1~ynh4"
+version = "0.24.2~ynh1"
 
 maintainers = []
 
@@ -53,14 +53,14 @@ ram.runtime = "50M"
 
     [resources.sources]
         [resources.sources.main]
-        arm64.url = "https://dl.vikunja.io/vikunja/0.24.1/vikunja-v0.24.1-linux-arm64-full.zip"
-        arm64.sha256 = "6642be9e0822ac8086c76823a2c090257f9cd5cacc2fd349ed12af520478ce55"
-        amd64.url = "https://dl.vikunja.io/vikunja/0.24.1/vikunja-v0.24.1-linux-amd64-full.zip"
-        amd64.sha256 = "62a5e936c7dc193fc0a2db46767ea015f2e45a06fd0e40b5b0918b05bfb2d1ff"
-        armhf.url = "https://dl.vikunja.io/vikunja/0.24.1/vikunja-v0.24.1-linux-arm-7-full.zip"
-        armhf.sha256 = "f7ff14b789376fd4cd41e331e6bd399538a64626891bd77f14258b3fec901346"
-        i386.url = "https://dl.vikunja.io/vikunja/0.24.1/vikunja-v0.24.1-linux-386-full.zip"
-        i386.sha256 = "a552c4e031cbe4f69b13636d326f4bfa525905211469e615e51bd6d8cc85f923"
+        arm64.url = "https://dl.vikunja.io/vikunja/0.24.2/vikunja-v0.24.2-linux-arm64-full.zip"
+        arm64.sha256 = "c2354bff0bbee3398e3438ca8fd9b76348ee868a08353aeb86a4481db364ce13"
+        amd64.url = "https://dl.vikunja.io/vikunja/0.24.2/vikunja-v0.24.2-linux-amd64-full.zip"
+        amd64.sha256 = "bc1452a238e7b4a8b380fc5a7cd391c154adb293ad085bf2e2c94c4fa310e99d"
+        armhf.url = "https://dl.vikunja.io/vikunja/0.24.2/vikunja-v0.24.2-linux-arm-7-full.zip"
+        armhf.sha256 = "03a141520726347935476d44f11729e5996b983ebd1fadeccf3e59d34f48c528"
+        i386.url = "https://dl.vikunja.io/vikunja/0.24.2/vikunja-v0.24.2-linux-386-full.zip"
+        i386.sha256 = "f3ae9427b4bacf636940dab7b87fe5cb92a9d48e6decbdbf2f02ae76ec5fe763"
         in_subdir = false
         format = "zip"
 


### PR DESCRIPTION
Update to version 0.24.2

## Problem

Version 0.24.2 was released: https://vikunja.io/changelog/vikunja-v0.24.2-was-released

## Solution

Updated ZIP URLs and hash sums.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
