### PR TITLE
Update to version 0.24.4

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Vikunja"
 description.en = "Self-hosted To-Do list application"
 description.fr = "Application de liste de tâches auto-hébergée"
 
-version = "0.24.2~ynh1"
+version = "0.24.4~ynh1"
 
 maintainers = []
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Vikunja"
 description.en = "Self-hosted To-Do list application"
 description.fr = "Application de liste de tâches auto-hébergée"
 
-version = "0.24.2~ynh2"
+version = "0.24.2~ynh1"
 
 maintainers = []
 
@@ -53,14 +53,14 @@ ram.runtime = "50M"
 
     [resources.sources]
         [resources.sources.main]
-        arm64.url = "https://dl.vikunja.io/vikunja/0.24.2/vikunja-v0.24.2-linux-arm64-full.zip"
-        arm64.sha256 = "c2354bff0bbee3398e3438ca8fd9b76348ee868a08353aeb86a4481db364ce13"
-        amd64.url = "https://dl.vikunja.io/vikunja/0.24.2/vikunja-v0.24.2-linux-amd64-full.zip"
-        amd64.sha256 = "bc1452a238e7b4a8b380fc5a7cd391c154adb293ad085bf2e2c94c4fa310e99d"
-        armhf.url = "https://dl.vikunja.io/vikunja/0.24.2/vikunja-v0.24.2-linux-arm-7-full.zip"
-        armhf.sha256 = "03a141520726347935476d44f11729e5996b983ebd1fadeccf3e59d34f48c528"
-        i386.url = "https://dl.vikunja.io/vikunja/0.24.2/vikunja-v0.24.2-linux-386-full.zip"
-        i386.sha256 = "f3ae9427b4bacf636940dab7b87fe5cb92a9d48e6decbdbf2f02ae76ec5fe763"
+        arm64.url = "https://dl.vikunja.io/vikunja/0.24.4/vikunja-v0.24.4-linux-arm64-full.zip"
+        arm64.sha256 = "22481d10ca03ed8c6a0089dee8d5b0302f905b24d6ea712dd46432f43fb391bb"
+        amd64.url = "https://dl.vikunja.io/vikunja/0.24.4/vikunja-v0.24.4-linux-amd64-full.zip"
+        amd64.sha256 = "dc39be6a24dc732bfce80f7e05b5262310b2bb23cde5c155a1867f92e22afb78"
+        armhf.url = "https://dl.vikunja.io/vikunja/0.24.4/vikunja-v0.24.4-linux-arm-7-full.zip"
+        armhf.sha256 = "d85a4d6cd68f51343f31b000d6b6b7dc791a4c8f0ddaaba7c774865478489c24"
+        i386.url = "https://dl.vikunja.io/vikunja/0.24.4/vikunja-v0.24.4-linux-386-full.zip"
+        i386.sha256 = "12b803a1e6f60dff67b94ebfb2f8a3066ce3a6618ac8ff41331fb0c21198fd56"
         in_subdir = false
         format = "zip"
 


### PR DESCRIPTION
Update version to 0.24.4

## Problem

Version 0.24.4 was released, see https://vikunja.io/changelog/vikunja-v0.24.4-was-released

## Solution

Updated ZIP URLs and hash sums.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
