### PR TITLE
Added Public URL to config.yml

### DIFF
--- a/conf/config.yml
+++ b/conf/config.yml
@@ -18,6 +18,8 @@ service:
   unixsocketmode:
   # The URL of the frontend, used to send password reset emails.
   frontendurl: "https://__DOMAIN__"
+  # The public facing URL where your users can reach Vikunja. Used in emails and for the communication between api and frontend.
+  publicurl: "https://__DOMAIN__/"
   # The base path on the file system where the binary and assets are.
   # Vikunja will also look in this path for a config file, so you could provide only this variable to point to a folder
   # with a config file which will then be used.


### PR DESCRIPTION
Added Public URL

## Problem

- *Having this variable empty as a default value doesn't provide a good user experience, as email reminders are not usable*

## Solution

- *I added the publicurl variable under service, and used the domain as a default value, with a trailing slash*

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
