### PR TITLE
[autopatch] Autopatch to use timedatectl instead of legacy /etc/timezone

### DIFF
--- a/scripts/change_url
+++ b/scripts/change_url
@@ -8,7 +8,7 @@ source /usr/share/yunohost/helpers
 #=================================================
 
 secret=$(ynh_string_random --length=32)
-timezone="$(cat /etc/timezone)"
+timezone="$(timedatectl show --value --property=Timezone)"
 redis_db=$(ynh_redis_get_free_db)
 
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -7,7 +7,7 @@ source /usr/share/yunohost/helpers
 # RETRIEVE ARGUMENTS FROM THE MANIFEST
 #=================================================
 
-timezone="$(cat /etc/timezone)"
+timezone="$(timedatectl show --value --property=Timezone)"
 secret=$(ynh_string_random --length=32)
 redis_db=$(ynh_redis_get_free_db)
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -7,7 +7,7 @@ source /usr/share/yunohost/helpers
 # LOAD SETTINGS
 #=================================================
 
-timezone="$(cat /etc/timezone)"
+timezone="$(timedatectl show --value --property=Timezone)"
 secret=$(ynh_string_random --length=32)
 redis_db=$(ynh_redis_get_free_db)
 


### PR DESCRIPTION
This is an automatic PR

This is an ***automated*** fix to use the timedatectl command instead of
`cat /etc/timezone`.