### PR TITLE
Enable cors for localhost

### DIFF
--- a/conf/config.yml
+++ b/conf/config.yml
@@ -138,11 +138,11 @@ cors:
   # Whether to enable or disable cors headers.
   # By default, this is enabled only for requests from the desktop application running on localhost.
   # Note: If you want to put the frontend and the api on separate domains or ports, you will need to adjust this setting accordingly.
-  enable: false
+  enable: true
   # A list of origins which may access the api. These need to include the protocol (`http://` or `https://`) and port, if any.
-  # origins:
-    # - "http://127.0.0.1:*"
-    # - "http://localhost:*"
+  origins:
+    - "http://127.0.0.1:*"
+    - "http://localhost:*"
   # How long (in seconds) the results of a preflight request can be cached.
   # maxage: 0
 # 


### PR DESCRIPTION
## Problem

Connection from desktop app to Vikunja installation failed. Same issue as here: https://github.com/go-vikunja/vikunja/issues/226 and https://community.vikunja.io/t/could-not-find-or-use-vikunja-installation-at-xxx-xxx-xxx-xxx-please-try-a-different-url/1675 .

## Solution

Enable cors for localhost in `config.yaml` (see docs: https://vikunja.io/docs/config-options/#0--cors).

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
