### PR TITLE
Fix regex for autoupdate

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -64,9 +64,9 @@ ram.runtime = "50M"
         format = "zip"
 
         autoupdate.strategy = "latest_github_release"
-        autoupdate.asset.amd64 = '.*-linux-amd64-full.zip'
-        autoupdate.asset.arm64 = '.*-linux-arm64-full.zip'
-        autoupdate.asset.armhf = '.*-linux-arm-7-full.zip'
+        autoupdate.asset.amd64 = 'vikunja-.*-linux-amd64-full.zip'
+        autoupdate.asset.arm64 = 'vikunja-.*-linux-arm64-full.zip'
+        autoupdate.asset.armhf = 'vikunja-.*-linux-arm-7-full.zip'
 
     [resources.system_user]
     allow_email = true


### PR DESCRIPTION
## Problem

Since release v2.4.0, the project publishes binaries for vikunja and veans, which broke the auto-update since two binaries were matching each regex.

For example, see https://paste.yunohost.org/raw/mimutebeqa

> Too many assets matching regex '.*-linux-amd64-full.zip': 'veans-v2.5.0-linux-amd64-full.zip', 'vikunja-v2.5.0-linux-amd64-full.zip'

From the docs, veans is:

> a small, experimental command-line tool for driving Vikunja from a terminal, a script, or a coding agent. It wraps Vikunja’s REST API with an agent-friendly surface and can emit a system prompt that teaches an agent to track its work in Vikunja instead of a scratch to-do list.

## Solution

So we should only consider the vikunja binaries.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
